### PR TITLE
Change `Bugsnag.TaskSupervisor` restart strategy to `:temporary`

### DIFF
--- a/lib/bugsnag.ex
+++ b/lib/bugsnag.ex
@@ -29,7 +29,7 @@ defmodule Bugsnag do
     end
 
     children = [
-      supervisor(Task.Supervisor, [[name: Bugsnag.TaskSupervisor, restart: :transient]])
+      supervisor(Task.Supervisor, [[name: Bugsnag.TaskSupervisor, restart: :temporary]])
     ]
 
     opts = [strategy: :one_for_one, name: Bugsnag.Supervisor]


### PR DESCRIPTION
This will stop the infinite retry loop of reports if for some reason bugsnag is
unavailable. Without that, it is possible to *crash* our app if, for some
reason, reports are imposible.

This is in part mitigated by the fact that `Task`s stop restarting after their
timeout, which default to 5s. That means, we'd need to accumulate enough error
reports in 5 seconds to have their restarts crashing the `TaskSupervisor`.

It is also important to note that such high number of restarts would make cpu usage go higher and higher. This would contribute to even more timeouts/restarts/errors. 

That would be indeed a terrible place to be.

Signed-off-by: Milhouse <renanranelli@gmail.com>